### PR TITLE
fix: search in fullpath

### DIFF
--- a/cmd/vault-kv-search.go
+++ b/cmd/vault-kv-search.go
@@ -160,8 +160,14 @@ func (vc *vaultClient) secretMatch(dirEntry string, fullPath string, searchObjec
 
 	if vc.useRegex {
 		found, _ = regexp.MatchString(vc.searchString, term)
+		if !found && searchObject == "path" {
+			found, _ = regexp.MatchString(vc.searchString, fullPath)
+		}
 	} else {
 		found = strings.Contains(term, vc.searchString)
+		if !found && searchObject == "path" {
+			found = strings.Contains(fullPath, vc.searchString)
+		}
 	}
 
 	if found {


### PR DESCRIPTION
The previous behavior search only in the end of the key path, now, we can find a entry by matching in the fullPath during the crawling.

Can you please cut a release then ? 🙏🏻 