### PR TITLE
chore: fix golangci-lint error

### DIFF
--- a/cmd/vault-kv-search.go
+++ b/cmd/vault-kv-search.go
@@ -240,7 +240,7 @@ func (vc *vaultClient) readLeafs(path string, searchObjects []string, version in
 	}
 
 	if len(pathList.Warnings) > 0 {
-		return fmt.Errorf(pathList.Warnings[0])
+		return errors.New(pathList.Warnings[0])
 	}
 
 	for _, x := range pathList.Data["keys"].([]interface{}) {


### PR DESCRIPTION
Error: cmd/vault-kv-search.go:243:21: printf: non-constant format string in call to fmt.Errorf (govet)