### PR TITLE
ci: replace bump-homebrew action with inline tap bump

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -85,14 +85,35 @@ jobs:
     needs: [release-please, release]
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ needs.release-please.outputs.tag_name }}
     steps:
-    - name: Update Homebrew formula
-      uses: mislav/bump-homebrew-formula-action@v4.1
-      with:
-        formula-name: vault-kv-search
-        homebrew-tap: xbglowx/homebrew-tap
-        tag-name: ${{ needs.release-please.outputs.tag_name }}
-        commit-message: |
-          chore: update {{formulaName}} to {{version}}
+    - name: Bump tap formula
       env:
         COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      run: |
+        set -euo pipefail
+
+        TARBALL="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${TAG}.tar.gz"
+        SHA256=$(curl -fsSL "$TARBALL" | sha256sum | cut -d' ' -f1)
+        echo "tarball=$TARBALL sha256=$SHA256"
+
+        git clone "https://x-access-token:${COMMITTER_TOKEN}@github.com/xbglowx/homebrew-tap.git" tap
+        cd tap
+
+        FORMULA="Formula/vault-kv-search.rb"
+        sed -i -E \
+          -e "s|^(\s*url\s+\").*(\".*)|\1${TARBALL}\2|" \
+          -e "s|^(\s*sha256\s+\").*(\".*)|\1${SHA256}\2|" \
+          "$FORMULA"
+
+        if git diff --quiet; then
+          echo "Formula already up to date"
+          exit 0
+        fi
+
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add "$FORMULA"
+        git commit -m "chore: update vault-kv-search to ${TAG}"
+        git push origin HEAD:main


### PR DESCRIPTION
## Problem

`update-homebrew` job fails with `Error: unexpected HTTP 303 response` ([example run](https://github.com/xbglowx/vault-kv-search/actions/runs/27803779894/job/82341659471)).

`mislav/bump-homebrew-formula-action@v4.1` HEADs the source tarball URL and checks `res.statusCode == 302` exact-equality. Since ~2026-05-16 GitHub returns **HTTP 303** (not 302) for codeload tarball redirects on Actions runners with the bearer token attached. Action rejects 303 → fails before bumping the tap.

Upstream: [mislav/bump-homebrew-formula-action#340](https://github.com/mislav/bump-homebrew-formula-action/issues/340), fix [PR #342](https://github.com/mislav/bump-homebrew-formula-action/pull/342) unmerged.

## Fix

Replace the action with an inline step:
- `curl -fsSL` (follows any 3xx) downloads the tarball, computes sha256
- `sed` bumps `url` + `sha256` in `Formula/vault-kv-search.rb`
- commits + pushes to `xbglowx/homebrew-tap`
- idempotent via `git diff --quiet` (safe on manual retries)

Same `HOMEBREW_TAP_TOKEN` secret. Homebrew auto-derives `version` from the url tag.

## Testing

Only runs on next release. v0.4.5 tap bump done manually out-of-band.